### PR TITLE
fixed the findFirst function on the linked list

### DIFF
--- a/lib/linkedList.js
+++ b/lib/linkedList.js
@@ -118,7 +118,8 @@ function linkedList() {
     };
 
     self.findFirst = function() {
-        return this.head.export();
+        var firstNode = this.head;
+        return firstNode !== null ? this.head.export() : null;
     };
 
     self.findLast = function() {

--- a/test/linkedList.spec.js
+++ b/test/linkedList.spec.js
@@ -8,6 +8,10 @@ describe('linkedList test', function() {
     it('should have initial count of 0', function(){
         expect(ll.count()).to.be.equal(0);
     });
+    
+    it('should not find the first node', function() {
+        expect(ll.findFirst()).to.be.equal(null);
+    });
 
     it('should add 2 nodes at first n1 and n2', function(){
         ll.addFirst('n2');


### PR DESCRIPTION
An error is thrown if you try to get the first element of an empty linked list.
```shell
return this.head.export();
                        ^

TypeError: Cannot read property 'export' of null
```
Now the findFirst function is just like the other find functions.
I added a test too.