### PR TITLE
use slice instead of shift in dequeuing elements form queue

### DIFF
--- a/lib/dataStructures/queue.js
+++ b/lib/dataStructures/queue.js
@@ -17,7 +17,7 @@
         };
         
         self.isEmpty = function() {
-            return this.elements.length == 0;
+            return this.elements.length === 0;
         };
 
         self.length = function() {

--- a/lib/dataStructures/queue.js
+++ b/lib/dataStructures/queue.js
@@ -28,7 +28,12 @@
         };
 
         self.dequeue = function() {
-            return !this.isEmpty() ? this.elements.shift() : null;
+            if (!this.isEmpty()) {
+                var first = this.elements[0];
+                this.elements = this.elements.slice(1);
+                return first;
+            }
+            return null;
         };
 
         self.front = function() {

--- a/lib/dataStructures/queue.js
+++ b/lib/dataStructures/queue.js
@@ -12,15 +12,16 @@
     var queue = function() {
         
         var self = {
+            offset: 0,
             elements: []
         };
         
         self.isEmpty = function() {
-            return this.elements.length > 0 ? false : true;
+            return this.elements.length == 0;
         };
 
         self.length = function() {
-            return this.elements.length;
+            return this.elements.length - this.offset;
         };
 
         self.enqueue = function(el) {
@@ -29,15 +30,19 @@
 
         self.dequeue = function() {
             if (!this.isEmpty()) {
-                var first = this.elements[0];
-                this.elements = this.elements.slice(1);
+                var first = this.elements[this.offset];
+                this.offset++;
+                if (this.offset * 2 >= this.length()){
+                  this.elements  = this.elements.slice(this.offset);
+                  this.offset = 0;
+                }
                 return first;
             }
             return null;
         };
 
         self.front = function() {
-            return !this.isEmpty() ? this.elements[0] : null;
+            return !this.isEmpty() ? this.elements[this.offset] : null;
         };
 
         self.back = function() {


### PR DESCRIPTION
slice has a better performance than shift. Also maintain an offset on the front element to limit using slice only when offset reaches half the queue. This makes significant performance improve for a queue that manages big amount of elements or where queue and dequeue happens at high frequency.