### PR TITLE
fix hastable remove function for collided elements

### DIFF
--- a/lib/dataStructures/hashtable.js
+++ b/lib/dataStructures/hashtable.js
@@ -67,19 +67,20 @@ module.exports = function(htPairFactory, htIteratorFactory, hashFunction) {
 
         // remove a key-value pair by by a given key
         self.remove = function(key) {
-            var i, length,
-            hash = hashFunction(key);
+            var i, hash = hashFunction(key);
             if (elements[hash] !== undefined) {
-                length = elements[hash].length;
-                if (length === 1) {
+                if (elements[hash].length === 1) {
                     delete elements[hash];
                     count--;
                 }
                 else {
-                    for (i = 0; i < length; i++) {
+                    for (i = 0; i < elements[hash].length; i) {
                         if (elements[hash][i].getKey() === key) {
                             elements[hash].splice(i, 1);
                             count--;
+                        }
+                        else {
+                            i++;
                         }
                     }
                 }

--- a/test/dataStructures/hashtable.spec.js
+++ b/test/dataStructures/hashtable.spec.js
@@ -102,6 +102,19 @@ describe('hashtable test', function() {
             expect(hashtable.get('eeeee')).to.be.equal(undefined);
             expect(hashtable.get('e')).to.be.equal(555);
             expect(hashtable.count()).to.be.equal(2);
+        });
+
+        it('should remove all elements', function() {
+            var ht = di.getFactory('ds', 'hashtable', 
+                [htPairFactory, htIteratorFactory, hashFunction])();
+            for (var i = 0; i < 1000; i++) {
+                ht.put(i, i);
+            }
+            expect(ht.count()).to.be.equal(1000);
+            for (var i = 0; i < 1000; i++) {
+                ht.remove(i);
+            }
+            expect(ht.count()).to.be.equal(0);
         }); 
 
     });


### PR DESCRIPTION
remove the static assignment of array length as its length is changing by the removal of the elements in addition to only increasing the index when the collided element is not removed.